### PR TITLE
[Role: All] Xem thông tin cá nhân

### DIFF
--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/config/SecurityConfig.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/config/SecurityConfig.java
@@ -50,7 +50,9 @@ public class SecurityConfig {
                                 AUTH_LOGOUT,
                                 AUTH_RECOVERY,
                                 AUTH_REGISTER_RENTER,
-                                AUTH_REGISTER_OWNER
+                                AUTH_REGISTER_OWNER,
+                                USER_ROLE,
+                                OWNER_VENUES
                         ).permitAll()
                         // Admin routes require ADMIN role
                         .requestMatchers(ADMIN_BASE).hasRole("ADMIN")

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/constant/Endpoint.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/constant/Endpoint.java
@@ -8,6 +8,8 @@ public class Endpoint {
 
     public static final String AUTH_REGISTER_RENTER = "/api/auth/register-renter";
     public static final String AUTH_REGISTER_OWNER  = "/api/auth/register-owner";
+    
+    public static final String USER_ROLE = "/api/users/**";
 
     public static final String OWNER_VENUES = "/api/owner/venues/**";
 

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/controller/api/AuthApiController.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/controller/api/AuthApiController.java
@@ -1,8 +1,6 @@
 package naitei.group5.workingspacebooking.controller.api;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import naitei.group5.workingspacebooking.dto.request.LoginRequest;
@@ -48,4 +46,5 @@ public class AuthApiController {
         if (token != null) authService.logout(token);
         return ResponseEntity.noContent().build();
     }
+    
 }

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/controller/api/user/UserController.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/controller/api/user/UserController.java
@@ -1,0 +1,23 @@
+package naitei.group5.workingspacebooking.controller.api.user;
+
+import lombok.RequiredArgsConstructor;
+import naitei.group5.workingspacebooking.config.JwtUserDetails;
+import naitei.group5.workingspacebooking.dto.response.UserResponse;
+import naitei.group5.workingspacebooking.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getProfile(@AuthenticationPrincipal JwtUserDetails userDetails) {
+        UserResponse response = userService.getUserProfile(userDetails);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/repository/UserRepository.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     boolean existsByEmail(String email);
 
     List<User> findByRole(UserRole role);
+    
+    Optional<User> findById(Integer id);
 }

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/service/UserService.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/service/UserService.java
@@ -1,9 +1,12 @@
 package naitei.group5.workingspacebooking.service;
 
+import naitei.group5.workingspacebooking.config.JwtUserDetails;
 import naitei.group5.workingspacebooking.dto.request.RegisterRequest;
 import naitei.group5.workingspacebooking.dto.response.RegisterResponse;
+import naitei.group5.workingspacebooking.dto.response.UserResponse;
 
 public interface UserService {
     RegisterResponse registerRenter(RegisterRequest request);
     RegisterResponse registerOwner(RegisterRequest request);
+    UserResponse getUserProfile(JwtUserDetails userDetails);
 }

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/service/impl/UserServiceImpl.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/service/impl/UserServiceImpl.java
@@ -2,16 +2,23 @@ package naitei.group5.workingspacebooking.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import naitei.group5.workingspacebooking.entity.enums.UserRole;
+import naitei.group5.workingspacebooking.exception.ResourceNotFoundException;
+import naitei.group5.workingspacebooking.utils.ConverterDto;
 import naitei.group5.workingspacebooking.utils.PasswordUtil;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import naitei.group5.workingspacebooking.config.JwtUserDetails;
 import naitei.group5.workingspacebooking.dto.request.RegisterRequest;
 import naitei.group5.workingspacebooking.dto.response.RegisterResponse;
+import naitei.group5.workingspacebooking.dto.response.UserResponse;
 import naitei.group5.workingspacebooking.entity.User;
 import naitei.group5.workingspacebooking.repository.UserRepository;
 import naitei.group5.workingspacebooking.service.EmailService;
 import naitei.group5.workingspacebooking.service.UserService;
 import java.security.SecureRandom;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +27,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private final EmailService emailService;
+	private final MessageSource messageSource;
 
     @Override
     public RegisterResponse registerRenter(RegisterRequest request) {
@@ -66,5 +74,21 @@ public class UserServiceImpl implements UserService {
                 .email(user.getEmail())
                 .role(user.getRole())
                 .build();
+    }
+
+    @Override
+    public UserResponse getUserProfile(JwtUserDetails userDetails) {
+        Integer userId = userDetails.getId();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        getMessage("user.profile.notfound", userId)
+                ));
+
+        return ConverterDto.toUserResponse(user);
+    }
+
+	private String getMessage(String key, Object... args) {
+        return messageSource.getMessage(key, args, LocaleContextHolder.getLocale());
     }
 }

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/utils/ConverterDto.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/utils/ConverterDto.java
@@ -1,20 +1,10 @@
 package naitei.group5.workingspacebooking.utils;
 
 import naitei.group5.workingspacebooking.dto.request.CreateVenueRequestDto;
-import naitei.group5.workingspacebooking.dto.response.PriceResponseDto;
-import naitei.group5.workingspacebooking.dto.response.BookingDetailResponseDto;
-import naitei.group5.workingspacebooking.dto.response.BookingResponseDto;
-import naitei.group5.workingspacebooking.dto.response.PriceDto;
-import naitei.group5.workingspacebooking.dto.response.TimeSlotResponseDto;
-import naitei.group5.workingspacebooking.dto.response.VenueDetailResponseDto;
-import naitei.group5.workingspacebooking.dto.response.VenueResponseDto;
 import naitei.group5.workingspacebooking.dto.request.UpdateVenueRequestDto;
 import naitei.group5.workingspacebooking.dto.response.*;
 import naitei.group5.workingspacebooking.entity.*;
 import naitei.group5.workingspacebooking.entity.enums.WeekDay;
-import naitei.group5.workingspacebooking.dto.response.VenueDetailRenterResponseDto;
-import naitei.group5.workingspacebooking.dto.response.BusySlotDto;
-
 
 import java.time.LocalTime;
 import java.util.*;
@@ -219,5 +209,17 @@ public final class ConverterDto {
     if (venueStyle != null) {
         venue.setVenueStyle(venueStyle);
     }
+    }
+
+     public static UserResponse toUserResponse(User user) {
+        if (user == null) return null;
+
+        return UserResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .role(user.getRole())
+                .build();
     }
 }

--- a/workingspacebooking/src/main/resources/messages.properties
+++ b/workingspacebooking/src/main/resources/messages.properties
@@ -9,3 +9,7 @@ venue.update.capacity.required=Capacity is required
 venue.update.capacity.min=Capacity must be greater than 0
 venue.update.location.required=Location is required
 venue.update.venueStyle.required=Venue style id is required
+
+# User profile
+user.profile.notfound=User not found with id: {0}
+user.profile.success=User profile retrieved successfully


### PR DESCRIPTION
## ✅ Checklist tự review pull trước khi ready để trainer review (Java Spring Boot)
- [x] Sử dụng **thụt lề 4 spaces** đồng nhất ở tất cả các files `.java`, `.xml`, `.html`, `.properties`, v.v. (cấu hình lại IntelliJ/VSCode nếu chưa setup).
- [x] Cuối mỗi file cần có **end line** (`\n`) để tránh lỗi đỏ khi diff trên Git.
- [x] Mỗi dòng nếu quá dài thì cần xuống dòng (tối đa **100 ký tự/dòng**, cài đặt wrap line trong IDE nếu cần).
- [x] `.gitignore` các file nhạy cảm (VD: `application-secret.properties`, `.env`, `/target/`, `.log`, `.class`, ...).
- [x] Tham khảo và tuân theo Java Coding Convention:
  - https://google.github.io/styleguide/javaguide.html
  - hoặc https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
- [x] Kiểm tra mỗi pull request **chỉ có 1 commit**, nếu nhiều hơn hãy dùng `git rebase -i` để gộp commit.
- [x] Cài đặt `Checkstyle`, `PMD`, hoặc plugin Java linter tương ứng trong IDE để kiểm tra coding convention. Format lại trước khi gửi pull.
- [x] Nếu làm việc nhóm, mỗi pull cần **ít nhất 1 APPROVED** từ thành viên khác trong nhóm.

---
## Related Tickets
- [#91147](https://edu-redmine.sun-asterisk.vn/issues/91147)

## WHAT 
Thêm tính năng xem thông tin cá nhân (User Profile).

## HOW
Entity/User: giữ nguyên để ánh xạ dữ liệu người dùng.

Repository/UserRepository: tận dụng findById để lấy user theo id.

DTO/UserResponse: tạo DTO chứa thông tin cơ bản cần trả về (id, name, email, phone, role).

Utils/ConverterDto: bổ sung hàm toUserResponse(User) để convert entity → DTO.

Service/UserService: thêm method getUserProfile(JwtUserDetails userDetails).

ServiceImpl/UserServiceImpl:

Lấy userId từ JwtUserDetails.

Gọi userRepository.findById(userId).

Nếu không tìm thấy → ném ResourceNotFoundException với message lấy từ messages.properties (user.profile.notfound).

Nếu tìm thấy → convert sang UserResponse và trả về.

Controller/AuthApiController: thêm endpoint GET /api/auth/me.

Chỉ cho phép gọi khi user đã đăng nhập bằng JWT.

Lấy JwtUserDetails từ context.

Gọi xuống userService.getUserProfile(userDetails) để trả về thông tin cá nhân.

messages.properties: thêm các message:

user.profile.notfound=User not found with id: {0}

user.profile.success=User profile retrieved successfully

## WHY 
Cần bổ sung API xem thông tin cá nhân để user có thể xem lại profile sau khi login bằng JWT.

Tránh hard-code string, sử dụng i18n messages để dễ maintain và hỗ trợ đa ngôn ngữ.

## Evidence (Screenshot or Video)
<img width="666" height="360" alt="image" src="https://github.com/user-attachments/assets/2964f7cc-9e45-49f3-aeb8-4ddb2cf95ed7" />
