### PR TITLE
feat: [Role: Admin] Duyệt / từ chối venue

### DIFF
--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/controller/mvc/admin/AdminVenueController.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/controller/mvc/admin/AdminVenueController.java
@@ -3,33 +3,102 @@ package naitei.group5.workingspacebooking.controller.mvc.admin;
 import lombok.RequiredArgsConstructor;
 import naitei.group5.workingspacebooking.dto.response.AdminVenueViewDto;
 import naitei.group5.workingspacebooking.service.VenueService;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.List;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor
 public class AdminVenueController extends BaseAdminController {
 
     private final VenueService venueService;
+    private final MessageSource messageSource;
 
     @GetMapping("/venues")
     public String listVenues(
             @RequestParam(required = false) String name,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String sort,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int size,
             Model model) {
+
+        // Phân trang
+        org.springframework.data.domain.Page<AdminVenueViewDto> venuesPage = 
+            venueService.adminListVenues(name, status, sort, page, size);
         
-        List<AdminVenueViewDto> venues = venueService.adminListVenues(name, status, sort);
-        
-        model.addAttribute("venues", venues);
+        model.addAttribute("venues", venuesPage);
         model.addAttribute("currentName", name);
         model.addAttribute("currentStatus", status);
         model.addAttribute("currentSort", sort);
+        model.addAttribute("currentPage", page);
+        model.addAttribute("currentSize", size);
+        
+        model.addAttribute("totalPages", venuesPage.getTotalPages());
+        model.addAttribute("totalElements", venuesPage.getTotalElements());
+        model.addAttribute("isShowAll", size == -1);
         
         return "admin/venues/list";
+    }
+
+    @GetMapping("/venues/verification")
+    public String venueVerificationPage(
+            @RequestParam(required = false, defaultValue = "unverified") String status,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int size,
+            Model model) {
+        
+        // Phân trang
+        org.springframework.data.domain.Page<AdminVenueViewDto> venuesPage = 
+            venueService.adminListVenues(null, status, "name_asc", page, size);
+        
+        model.addAttribute("venues", venuesPage);
+        model.addAttribute("currentStatus", status);
+        model.addAttribute("currentPage", page);
+        model.addAttribute("currentSize", size);
+        
+        model.addAttribute("totalPages", venuesPage.getTotalPages());
+        model.addAttribute("totalElements", venuesPage.getTotalElements());
+        model.addAttribute("isShowAll", size == -1);
+        
+        return "admin/venues/verification";
+    }
+
+    @PatchMapping("/venues/{id}/approve")
+    public String approveVenue(@PathVariable Integer id,
+                              @RequestParam(required = false, defaultValue = "unverified") String status,
+                              @RequestParam(required = false, defaultValue = "0") int page,
+                              @RequestParam(required = false, defaultValue = "20") int size,
+                              RedirectAttributes redirectAttributes) {
+        
+        venueService.approveVenue(id);
+        String message = messageSource.getMessage("venue.approve.success", 
+                null, 
+                LocaleContextHolder.getLocale());
+        redirectAttributes.addFlashAttribute("successMessage", message);
+        
+        return "redirect:/admin/venues/verification?status=" + status + "&page=" + page + "&size=" + size;
+    }
+
+    @PatchMapping("/venues/{id}/unverify")
+    public String unverifyVenue(@PathVariable Integer id,
+                               @RequestParam(required = false, defaultValue = "unverified") String status,
+                               @RequestParam(required = false, defaultValue = "0") int page,
+                               @RequestParam(required = false, defaultValue = "20") int size,
+                               RedirectAttributes redirectAttributes) {
+        
+        venueService.unverifyVenue(id);
+        String message = messageSource.getMessage("venue.unverify.success", 
+                null, 
+                LocaleContextHolder.getLocale());
+        redirectAttributes.addFlashAttribute("successMessage", message);
+        
+        return "redirect:/admin/venues/verification?status=" + status + "&page=" + page + "&size=" + size;
     }
 }

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/AdminExceptionHandler.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/AdminExceptionHandler.java
@@ -1,0 +1,131 @@
+package naitei.group5.workingspacebooking.exception;
+
+import naitei.group5.workingspacebooking.exception.custom.VenueNotFoundException;
+import naitei.group5.workingspacebooking.exception.custom.VenueVerificationException;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+// Exception handler cho các trang Admin MVC
+@ControllerAdvice(basePackages = "naitei.group5.workingspacebooking.controller.mvc.admin")
+@Component
+public class AdminExceptionHandler {
+
+    private final MessageSource messageSource;
+
+    public AdminExceptionHandler(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    @ExceptionHandler({VenueNotFoundException.class, ResourceNotFoundException.class})
+    public String handleResourceNotFoundException(Exception ex, 
+                                                  RedirectAttributes redirectAttributes,
+                                                  HttpServletRequest request) {
+        String message = "Resource not found";
+        
+        if (ex instanceof VenueNotFoundException) {
+            VenueNotFoundException venueEx = (VenueNotFoundException) ex;
+            try {
+                message = messageSource.getMessage("venue.error.notfound", 
+                        new Object[]{venueEx.getVenueId()}, 
+                        LocaleContextHolder.getLocale());
+            } catch (Exception e) {
+                message = ex.getMessage();
+            }
+        } else {
+            message = ex.getMessage();
+        }
+        
+        redirectAttributes.addFlashAttribute("errorMessage", message);
+        
+        return determineRedirectPath(request);
+    }
+
+    @ExceptionHandler(VenueVerificationException.class)
+    public String handleVenueVerificationException(VenueVerificationException ex, 
+                                                  RedirectAttributes redirectAttributes,
+                                                  HttpServletRequest request) {
+        String messageKey = "venue.error." + ex.getOperation();
+        String message;
+        
+        try {
+            message = messageSource.getMessage(messageKey, 
+                                             new Object[]{ex.getVenueId()}, 
+                                             LocaleContextHolder.getLocale());
+        } catch (Exception e) {
+            try {
+                message = messageSource.getMessage("venue.error.generic", 
+                                                 null, 
+                                                 LocaleContextHolder.getLocale());
+            } catch (Exception e2) {
+                message = ex.getMessage();
+            }
+        }
+        
+        redirectAttributes.addFlashAttribute("errorMessage", message);
+        
+        return determineRedirectPath(request);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public String handleIllegalStateException(IllegalStateException ex, 
+                                             RedirectAttributes redirectAttributes,
+                                             HttpServletRequest request) {
+        String messageKey = ex.getMessage();
+        String message;
+        
+        try {
+            message = messageSource.getMessage(messageKey, null, LocaleContextHolder.getLocale());
+        } catch (Exception e) {
+            message = ex.getMessage();
+        }
+        
+        redirectAttributes.addFlashAttribute("errorMessage", message);
+        
+        return determineRedirectPath(request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public String handleGenericException(Exception ex, 
+                                       RedirectAttributes redirectAttributes,
+                                       HttpServletRequest request) {
+        String message;
+        
+        try {
+            message = messageSource.getMessage("error.general", 
+                    null, 
+                    "An unexpected error occurred", 
+                    LocaleContextHolder.getLocale());
+        } catch (Exception e) {
+            message = "An unexpected error occurred: " + ex.getMessage();
+        }
+        
+        redirectAttributes.addFlashAttribute("errorMessage", message);
+        
+        return determineRedirectPath(request);
+    }
+
+    private String determineRedirectPath(HttpServletRequest request) {
+        String referer = request.getHeader("Referer");
+        
+        if (referer != null) {
+            if (referer.contains("/admin/venues/verification")) {
+                return "redirect:/admin/venues/verification";
+            }
+            if (referer.contains("/admin/users")) {
+                return "redirect:/admin/users";
+            }
+            if (referer.contains("/admin/venues")) {
+                return "redirect:/admin/venues";
+            }
+        }
+        
+        // Default fallback
+        return "redirect:/admin/dashboard";
+    }
+}

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/ErrorCode.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     VENUE_NOT_FOUND(HttpStatus.NOT_FOUND, "Venue not found"),
     VENUE_ALREADY_EXISTS(HttpStatus.CONFLICT, "Venue already exists"),
     VENUE_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "Venue not verified"),
+    VENUE_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "Venue verification operation failed"),
     PRICE_RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "Price rule not found for this slot"),
 
     // BOOKING

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/custom/VenueNotFoundException.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/custom/VenueNotFoundException.java
@@ -1,11 +1,23 @@
 package naitei.group5.workingspacebooking.exception.custom;
 
-
 import naitei.group5.workingspacebooking.exception.ApiException;
 import naitei.group5.workingspacebooking.exception.ErrorCode;
 
 public class VenueNotFoundException extends ApiException {
+    
+    private final Integer venueId;
+    
     public VenueNotFoundException() {
         super(ErrorCode.VENUE_NOT_FOUND);
+        this.venueId = null;
+    }
+    
+    public VenueNotFoundException(Integer venueId) {
+        super(ErrorCode.VENUE_NOT_FOUND);
+        this.venueId = venueId;
+    }
+    
+    public Integer getVenueId() {
+        return venueId;
     }
 }

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/custom/VenueVerificationException.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/exception/custom/VenueVerificationException.java
@@ -1,0 +1,31 @@
+package naitei.group5.workingspacebooking.exception.custom;
+
+import naitei.group5.workingspacebooking.exception.ApiException;
+import naitei.group5.workingspacebooking.exception.ErrorCode;
+
+public class VenueVerificationException extends ApiException {
+    
+    private final String operation;
+    private final Integer venueId;
+    
+    public VenueVerificationException(String operation, Integer venueId, String message) {
+        super(ErrorCode.VENUE_VERIFICATION_FAILED);
+        this.operation = operation;
+        this.venueId = venueId;
+    }
+    
+    public VenueVerificationException(String operation, Integer venueId, String message, Throwable cause) {
+        super(ErrorCode.VENUE_VERIFICATION_FAILED);
+        this.operation = operation;
+        this.venueId = venueId;
+        this.initCause(cause);
+    }
+    
+    public String getOperation() {
+        return operation;
+    }
+    
+    public Integer getVenueId() {
+        return venueId;
+    }
+}

--- a/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/service/VenueService.java
+++ b/workingspacebooking/src/main/java/naitei/group5/workingspacebooking/service/VenueService.java
@@ -38,6 +38,10 @@ public interface VenueService {
     VenueDetailRenterResponseDto getVenueDetail(Integer venueId);
 
     // ==== Admin use cases ====
-    List<AdminVenueViewDto> adminListVenues(String name, String status, String sort);
+    org.springframework.data.domain.Page<AdminVenueViewDto> adminListVenues(String name, String status, String sort, int page, int size);
+
+    // Admin venue verification
+    void approveVenue(Integer id);
+    void unverifyVenue(Integer id);
 
 }

--- a/workingspacebooking/src/main/resources/application.properties.example
+++ b/workingspacebooking/src/main/resources/application.properties.example
@@ -24,6 +24,9 @@ spring.messages.basename=i18n/messages
 spring.messages.encoding=UTF-8
 spring.messages.fallback-to-system-locale=false
 
+# Enable HTTP Method Override for RESTful
+spring.mvc.hiddenmethod.filter.enabled=true
+
 # Async Configuration for Email Sending
 spring.task.execution.pool.core-size=5
 spring.task.execution.pool.max-size=20

--- a/workingspacebooking/src/main/resources/i18n/messages.properties
+++ b/workingspacebooking/src/main/resources/i18n/messages.properties
@@ -106,25 +106,32 @@ user.profile.update.name.size=Name must be between 2 and 100 characters
 user.profile.update.phone.required=Phone number is required
 user.profile.update.phone.pattern=Phone number must be 9-15 digits
 
+# User Profile Service Messages
+user.profile.success=User profile retrieved successfully
+
 # ========================================
 # VENUE MANAGEMENT
 # ========================================
-venue.admin.list.title=Venue Management
+venue.admin.list.title=Co-working Space Management
 venue.admin.filter.name=Name
 venue.admin.filter.status=Status
 venue.admin.filter.sort=Sort by
 venue.admin.filter.all.status=All Status
-venue.table.empty=No venues found
+venue.table.empty=No Co-working Spaces found
 
 # Venue Status
 venue.status.unverified=Unverified
 venue.status.verified=Verified
 venue.status.deleted=Deleted
 
+# Venue Capacity
+venue.person.capacity=people
+
 # Venue Columns
 venue.column.owner=Owner
 venue.column.capacity=Capacity
 venue.column.location=Location
+venue.column.style=Style
 venue.column.status=Status
 venue.column.verified=Verified
 venue.column.deleted=Deleted
@@ -136,12 +143,11 @@ venue.sort.capacity_asc=Capacity Low-High
 venue.sort.capacity_desc=Capacity High-Low
 
 # Venue API Messages
-venue.list.verified=Verified venue list fetched successfully
-venue.list.filtered=Venue list filtered successfully
-venue.detail.success=Successfully retrieved venue detail
-venue.softdelete.success=Venue has been soft deleted successfully
-venue.softdelete.notfound=Venue not found with ID: {0} for owner: {1}
-owner.bookings.success=Fetched booking successfully
+venue.list.verified=Verified Co-working Space list fetched successfully
+venue.list.filtered=Co-working Space list filtered successfully
+venue.detail.success=Successfully retrieved Co-working Space detail
+venue.softdelete.success=Co-working Space has been soft deleted successfully
+venue.softdelete.notfound=Co-working Space not found with ID: {0} for owner: {1}
 
 # Venue Validation Messages
 venue.update.name.required=Name is required
@@ -150,10 +156,50 @@ venue.update.capacity.min=Capacity must be greater than 0
 venue.update.location.required=Location is required
 venue.update.venueStyle.required=Venue style id is required
 
+# Venue Validation Messages
+venue.update.name.required=Name is required
+venue.update.capacity.required=Capacity is required
+venue.update.capacity.min=Capacity must be greater than 0
+venue.update.location.required=Location is required
+venue.update.venueStyle.required=Venue style id is required
+
+# Venue Verification
+venue.action.approve=Approve
+venue.action.unverify=Unverify
+venue.verification.title=Co-Working Space Verification
+venue.verification.filter.all=All
+venue.verification.filter.verified=Verified
+venue.verification.filter.unverified=Unverified
+venue.approve.success=Co-working Space approved successfully
+venue.unverify.success=Co-working Space unverified successfully
+venue.approve.already=Co-working Space is already approved
+venue.unverify.already=Co-working Space is already unverified
+venue.back.to.list=Back to Co-working space list
+
+# Venue Pagination
+venue.pagination.perpage=Display/page
+venue.pagination.all=All
+venue.pagination.info=Showing {0} of {1} Co-working Spaces
+
+# Pagination
+pagination.previous=‹ Previous
+pagination.next=Next ›
+
+# Venue Error Messages
+venue.error.notfound=Co-working Space with ID {0} not found
+venue.error.approve=Failed to approve Co-working Space with ID {0}
+venue.error.unverify=Failed to unverify Co-working Space with ID {0}
+venue.error.generic=An unexpected error occurred while processing Co-working Space operations
+venue.error.operation=Cannot perform operation on deleted Co-working Space
+
+# General Error Messages
+error.general=An unexpected error occurred. Please try again later.
+
 # ========================================
 # BOOKING MANAGEMENT
 # ========================================
 booking.history.success=Fetched booking history successfully
+owner.bookings.success=Fetched booking successfully
 
 # ========================================
 # PRODUCT MANAGEMENT

--- a/workingspacebooking/src/main/resources/i18n/messages_vi.properties
+++ b/workingspacebooking/src/main/resources/i18n/messages_vi.properties
@@ -107,25 +107,32 @@ user.profile.update.name.size=Tên phải từ 2 đến 100 ký tự
 user.profile.update.phone.required=Số điện thoại là bắt buộc
 user.profile.update.phone.pattern=Số điện thoại phải từ 9-15 chữ số
 
+# User Profile Service Messages
+user.profile.success=Thông tin người dùng đã được lấy thành công
+
 # ========================================
 # VENUE MANAGEMENT
 # ========================================
-venue.admin.list.title=Quản lý địa điểm
+venue.admin.list.title=Quản lý Co-working Space
 venue.admin.filter.name=Tên
 venue.admin.filter.status=Trạng thái
 venue.admin.filter.sort=Sắp xếp theo
 venue.admin.filter.all.status=Tất cả trạng thái
-venue.table.empty=Không tìm thấy địa điểm nào
+venue.table.empty=Không tìm thấy Co-working Space nào
 
 # Venue Status
 venue.status.unverified=Chưa xác minh
 venue.status.verified=Đã xác minh
 venue.status.deleted=Đã xóa
 
+# Venue Capacity
+venue.person.capacity=chỗ
+
 # Venue Columns
 venue.column.owner=Chủ sở hữu
 venue.column.capacity=Sức chứa
-venue.column.location=Địa điểm
+venue.column.location=Vị trí
+venue.column.style=Kiểu
 venue.column.status=Trạng thái
 venue.column.verified=Đã xác minh
 venue.column.deleted=Đã xóa
@@ -140,20 +147,60 @@ venue.sort.capacity_desc=Sức chứa cao-thấp
 venue.list.verified=Đã lấy danh sách venue đã xác minh thành công
 venue.list.filtered=Đã lọc danh sách venue thành công
 venue.detail.success=Đã lấy chi tiết venue thành công
-venue.softdelete.success=Địa điểm đã được xóa mềm thành công
-venue.softdelete.notfound=Không tìm thấy địa điểm với ID: {0} cho owner: {1}
-owner.bookings.success=Lấy danh sách booking thành công
+venue.softdelete.success=Co-working Space đã được xóa mềm thành công
+venue.softdelete.notfound=Không tìm thấy Co-working Space với ID: {0} cho owner: {1}
+
 # Venue Validation Messages
 venue.update.name.required=Tên là bắt buộc
 venue.update.capacity.required=Sức chứa là bắt buộc
 venue.update.capacity.min=Sức chứa phải lớn hơn 0
-venue.update.location.required=Địa điểm là bắt buộc
+venue.update.location.required=Vị trí là bắt buộc
 venue.update.venueStyle.required=ID kiểu venue là bắt buộc
+
+# Venue Validation Messages
+venue.update.name.required=Tên là bắt buộc
+venue.update.capacity.required=Sức chứa là bắt buộc
+venue.update.capacity.min=Sức chứa phải lớn hơn 0
+venue.update.location.required=Vị trí là bắt buộc
+venue.update.venueStyle.required=ID kiểu venue là bắt buộc
+
+# Venue Verification
+venue.action.approve=Duyệt
+venue.action.unverify=Bỏ duyệt
+venue.verification.title=Quản lý duyệt Co-working Space
+venue.verification.filter.all=Tất cả
+venue.verification.filter.verified=Đã duyệt
+venue.verification.filter.unverified=Chưa duyệt
+venue.approve.success=Duyệt Co-working Space thành công
+venue.unverify.success=Bỏ duyệt Co-working Space thành công
+venue.approve.already=Co-working Space đã được duyệt
+venue.unverify.already=Co-working Space chưa được duyệt
+venue.back.to.list=Quay về danh sách Co-working space
+
+# Venue Pagination
+venue.pagination.perpage=Hiển thị/trang
+venue.pagination.all=Tất cả
+venue.pagination.info=Hiển thị {0} trên tổng {1} Co-working Space
+
+# Pagination
+pagination.previous=‹ Trước
+pagination.next=Tiếp ›
+
+# Venue Error Messages
+venue.error.notfound=Không tìm thấy Co-working Space với ID {0}
+venue.error.approve=Không thể duyệt Co-working Space với ID {0}
+venue.error.unverify=Không thể bỏ duyệt Co-working Space với ID {0}
+venue.error.generic=Đã xảy ra lỗi không mong muốn khi xử lý thao tác Co-working Space
+venue.error.operation=Không thể thực hiện thao tác trên Co-working Space đã bị xóa
+
+# General Error Messages  
+error.general=Đã xảy ra lỗi không mong muốn. Vui lòng thử lại sau.
 
 # ========================================
 # BOOKING MANAGEMENT
 # ========================================
 booking.history.success=Lấy lịch sử đặt chỗ thành công
+owner.bookings.success=Lấy danh sách booking thành công
 
 # ========================================
 # PRODUCT MANAGEMENT

--- a/workingspacebooking/src/main/resources/static/css/style.css
+++ b/workingspacebooking/src/main/resources/static/css/style.css
@@ -1,7 +1,50 @@
-/* ===== Admin Layout CSS =====
-   - File CSS chính cho admin interface
-   - Chứa styles cho sidebar navigation và language switcher
-*/
+/* ===== ADMIN INTERFACE CSS =====
+ * File CSS tổng hợp cho toàn bộ admin interface
+ * Bao gồm: Layout, Navigation, Forms, Components
+ */
+
+/* ===== Admin Layout Styles ===== */
+.admin-layout {
+    min-height: 100vh;
+    display: flex;
+}
+
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 25%;
+    height: 100vh;
+    background-color: #212529 !important;
+    overflow-y: auto;
+    z-index: 1000;
+}
+
+.main-content {
+    flex: 1;
+    margin-left: 25%;
+    background-color: white;
+    padding: 1.5rem;
+    min-height: 100vh;
+}
+
+/* Scroll styling for sidebar */
+.sidebar::-webkit-scrollbar {
+    width: 6px;
+}
+
+.sidebar::-webkit-scrollbar-track {
+    background: #343a40;
+}
+
+.sidebar::-webkit-scrollbar-thumb {
+    background: #6c757d;
+    border-radius: 3px;
+}
+
+.sidebar::-webkit-scrollbar-thumb:hover {
+    background: #adb5bd;
+}
 
 /* ===== Sidebar Navigation Styles ===== */
 .sidebar-nav-item {
@@ -30,12 +73,78 @@
 }
 
 /* ===== Language Switcher Styles ===== */
+/* Custom Dropdown without Bootstrap */
+.custom-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-btn {
+    background-color: #fff;
+    border: 1px solid #6c757d;
+    border-radius: 0.375rem;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: all 0.15s ease-in-out;
+    color: #6c757d;
+}
+
+.dropdown-btn:hover {
+    background-color: #e9ecef;
+    border-color: #5c636a;
+    color: #5c636a;
+}
+
+.dropdown-arrow {
+    font-size: 0.75rem;
+    transition: transform 0.15s ease-in-out;
+}
+
+.custom-dropdown.show .dropdown-arrow {
+    transform: rotate(180deg);
+}
+
+.dropdown-menu-custom {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 1000;
+    display: none;
+    min-width: 10rem;
+    padding: 0.5rem 0;
+    margin: 0.125rem 0 0;
+    background-color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.175);
+    border-radius: 0.375rem;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.175);
+}
+
+.custom-dropdown.show .dropdown-menu-custom {
+    display: block;
+}
+
 .language-item {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    clear: both;
+    font-weight: 400;
+    color: #212529;
+    text-align: inherit;
+    text-decoration: none;
+    white-space: nowrap;
+    background-color: transparent;
+    border: 0;
     transition: all 0.2s ease-in-out;
 }
 
 .language-item:hover {
     background-color: #f8f9fa !important;
+    color: #1e2125;
 }
 
 .language-item.active {
@@ -157,4 +266,12 @@
 .chart-card:hover {
     transform: translateY(-2px);
     transition: transform 0.3s ease;
+/* ===== Admin Form Components ===== */
+.venue-inline-form {
+    display: inline;
+}
+
+/* Utility Classes */
+.d-inline-form {
+    display: inline;
 }

--- a/workingspacebooking/src/main/resources/static/js/main.js
+++ b/workingspacebooking/src/main/resources/static/js/main.js
@@ -1,22 +1,70 @@
-/* ===== Admin Interface JavaScript =====
- * - Language switcher functionality
- * - Sidebar navigation highlighting
- * - DOM ready initialization
+/* ===== ADMIN INTERFACE JAVASCRIPT =====
+ * File JavaScript tổng hợp cho toàn bộ admin interface
+ * Bao gồm: Language switcher, Navigation, DOM initialization
  */
 
 document.addEventListener("DOMContentLoaded", function () {
     initializeLanguageSwitcher();
     initializeSidebarNavigation();
+    initializeLanguageSwitcherEvents();
+    initializeClickOutsideHandler();
 });
 
+// ===== Custom Dropdown Functions =====
+
+function toggleDropdown() {
+    const dropdown = document.querySelector('.custom-dropdown');
+    const isShow = dropdown.classList.contains('show');
+    
+    if (isShow) {
+        closeDropdown();
+    } else {
+        openDropdown();
+    }
+}
+
+function openDropdown() {
+    const dropdown = document.querySelector('.custom-dropdown');
+    dropdown.classList.add('show');
+}
+
+function closeDropdown() {
+    const dropdown = document.querySelector('.custom-dropdown');
+    dropdown.classList.remove('show');
+}
+
+function initializeClickOutsideHandler() {
+    document.addEventListener('click', function(event) {
+        const dropdown = document.querySelector('.custom-dropdown');
+        if (dropdown && !dropdown.contains(event.target)) {
+            closeDropdown();
+        }
+    });
+}
+
 // ===== Language Switcher Functions =====
+
+/**
+ * Khởi tạo event listeners cho language switcher
+ */
+function initializeLanguageSwitcherEvents() {
+    const languageItems = document.querySelectorAll('.language-item');
+    
+    languageItems.forEach(item => {
+        item.addEventListener('click', function(e) {
+            e.preventDefault();
+            const lang = this.getAttribute('data-lang');
+            changeLanguage(lang);
+        });
+    });
+}
 
 /**
  * Thay đổi ngôn ngữ của trang
  * @param {string} lang - Mã ngôn ngữ ('vi' hoặc 'en')
  */
 function changeLanguage(lang) {
-    const url = new URL(window.location);
+    const url = new URL(window.location.href);
     url.searchParams.set('lang', lang);
     window.location.href = url.toString();
 }

--- a/workingspacebooking/src/main/resources/templates/admin/users/user-list.html
+++ b/workingspacebooking/src/main/resources/templates/admin/users/user-list.html
@@ -66,7 +66,7 @@
                 <form th:if="${user.role.name() == 'pending_owner'}"
                       th:action="@{'/admin/users/' + ${user.id} + '/approve-owner'}"
                       method="post"
-                      style="display:inline;">
+                      class="d-inline-form">
                     <button type="submit" class="btn btn-success btn-sm" th:text="#{user.action.approve.owner}">Approve</button>
                 </form>
                 <span th:unless="${user.role.name() == 'pending_owner'}" class="text-muted">—</span>

--- a/workingspacebooking/src/main/resources/templates/admin/venues/verification.html
+++ b/workingspacebooking/src/main/resources/templates/admin/venues/verification.html
@@ -5,71 +5,50 @@
 <head>
     <meta charset="UTF-8">
 </head>
-<body th:with="pageTitle=#{venue.admin.list.title}">
+<body th:with="pageTitle=#{venue.verification.title}">
 <div layout:fragment="content">
-    <h2 th:text="#{venue.admin.list.title}">Co-working Space Management</h2>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 th:text="#{venue.verification.title}">Xác thực Co-Working Space</h2>
+        <a th:href="@{/admin/venues}" class="btn btn-outline-primary">
+            <i class="fas fa-arrow-left me-2"></i><span th:text="#{venue.back.to.list}">Quay về danh sách Co-working space</span>
+        </a>
+    </div>
     <hr class="text-secondary">
     
-    <!-- Navigation Button -->
-    <div class="mb-3">
-        <a th:href="@{/admin/venues/verification}" class="btn btn-primary">
-            <span th:text="#{venue.verification.title}">Xác thực Co-Working Space</span>
-        </a>
+    <!-- Flash Messages -->
+    <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
+        <span th:text="${successMessage}"></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${errorMessage}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${errorMessage}"></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
     
     <!-- Filter Form -->
     <div class="card mb-4">
         <div class="card-body">
-            <form method="GET" th:action="@{/admin/venues}">
+            <form method="GET" th:action="@{/admin/venues/verification}">
                 <div class="row">
-                    <div class="col-md-2">
-                        <label for="name" class="form-label" 
-                               th:text="#{venue.admin.filter.name}">Name</label>
-                        <input type="text" class="form-control" id="name" name="name" 
-                               th:value="${currentName}">
-                    </div>
-                    <div class="col-md-2">
+                    <div class="col-md-3">
                         <label for="status" class="form-label" 
                                th:text="#{venue.admin.filter.status}">Status</label>
                         <select class="form-control" id="status" name="status">
-                            <option value="" 
-                                    th:selected="${currentStatus == null or currentStatus == ''}"
-                                    th:text="#{venue.admin.filter.all.status}">
-                                All Status
-                            </option>
+                            <option value="all" 
+                                    th:selected="${currentStatus == 'all'}"
+                                    th:text="#{venue.verification.filter.all}">Tất cả</option>
                             <option value="unverified" 
-                                    th:selected="${currentStatus == 'unverified'}"
-                                    th:text="#{venue.status.unverified}">Unverified</option>
+                                    th:selected="${currentStatus == null or currentStatus == '' or currentStatus == 'unverified'}"
+                                    th:text="#{venue.verification.filter.unverified}">Chưa duyệt</option>
                             <option value="verified" 
                                     th:selected="${currentStatus == 'verified'}"
-                                    th:text="#{venue.status.verified}">Verified</option>
-                            <option value="deleted" 
-                                    th:selected="${currentStatus == 'deleted'}"
-                                    th:text="#{venue.status.deleted}">Deleted</option>
+                                    th:text="#{venue.verification.filter.verified}">Đã duyệt</option>
                         </select>
                     </div>
                     <div class="col-md-3">
-                        <label for="sort" class="form-label" 
-                               th:text="#{venue.admin.filter.sort}">Sort</label>
-                        <select class="form-control" id="sort" name="sort">
-                            <option value="name_asc" 
-                                    th:selected="${currentSort == null or currentSort == '' or currentSort == 'name_asc'}"
-                                    th:text="#{venue.sort.name_asc}">Name A-Z</option>
-                            <option value="name_desc" 
-                                    th:selected="${currentSort == 'name_desc'}"
-                                    th:text="#{venue.sort.name_desc}">Name Z-A</option>
-                            <option value="capacity_asc" 
-                                    th:selected="${currentSort == 'capacity_asc'}"
-                                    th:text="#{venue.sort.capacity_asc}">Capacity Low-High</option>
-                            <option value="capacity_desc" 
-                                    th:selected="${currentSort == 'capacity_desc'}"
-                                    th:text="#{venue.sort.capacity_desc}">Capacity High-Low</option>
-                        </select>
-                    </div>
-                    <div class="col-md-2">
                         <label for="size" class="form-label" th:text="#{venue.pagination.perpage}">Hiển thị/trang</label>
                         <select class="form-control" id="size" name="size">
-                            <option value="20" th:selected="${currentSize == null or currentSize == 20}" th:text="20">20</option>
+                            <option value="20" th:selected="${currentSize == 20}" th:text="20">20</option>
                             <option value="50" th:selected="${currentSize == 50}" th:text="50">50</option>
                             <option value="100" th:selected="${currentSize == 100}" th:text="100">100</option>
                             <option value="-1" th:selected="${currentSize == -1}" th:text="#{venue.pagination.all}">Tất cả</option>
@@ -79,7 +58,12 @@
                         <label class="form-label">&nbsp;</label>
                         <div class="d-grid gap-2">
                             <button type="submit" class="btn btn-primary" th:text="#{common.filter}">Filter</button>
-                            <a th:href="@{/admin/venues}" class="btn btn-secondary" th:text="#{common.reset}">Reset</a>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">&nbsp;</label>
+                        <div class="d-grid gap-2">
+                            <a th:href="@{/admin/venues/verification}" class="btn btn-secondary" th:text="#{common.reset}">Reset</a>
                         </div>
                     </div>
                 </div>
@@ -98,6 +82,7 @@
                 <th th:text="#{venue.column.location}">Location</th>
                 <th th:text="#{venue.column.style}">Style</th>
                 <th th:text="#{venue.column.status}">Status</th>
+                <th th:text="#{common.actions}">Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -111,19 +96,42 @@
                 <td>
                     <span th:if="${venueView.deleted}" 
                           class="badge bg-danger" 
-                          th:text="#{venue.status.deleted}">Đã xóa</span>
-                    
+                          th:text="#{venue.status.deleted}">Deleted</span>
                     <span th:if="${!venueView.deleted and venueView.venue.verified}" 
                           class="badge bg-success" 
-                          th:text="#{venue.status.verified}">Đã duyệt</span>
-                    
+                          th:text="#{venue.status.verified}">Verified</span>
                     <span th:if="${!venueView.deleted and !venueView.venue.verified}" 
                           class="badge bg-warning text-dark" 
-                          th:text="#{venue.status.unverified}">Chưa duyệt</span>
+                          th:text="#{venue.status.unverified}">Unverified</span>
+                </td>
+                <td>
+                    <!-- Single Actions -->
+                    <div th:if="${!venueView.deleted}">
+                        <form th:if="${!venueView.venue.verified}" 
+                              th:action="@{/admin/venues/{id}/approve(id=${venueView.venue.id})}" 
+                              method="post" class="d-inline-form">
+                            <input type="hidden" name="_method" value="patch">
+                            <input type="hidden" name="status" th:value="${currentStatus}">
+                            <input type="hidden" name="page" th:value="${currentPage}">
+                            <input type="hidden" name="size" th:value="${currentSize}">
+                            <button type="submit" class="btn btn-sm btn-success" 
+                                    th:text="#{venue.action.approve}">Duyệt</button>
+                        </form>
+                        <form th:if="${venueView.venue.verified}" 
+                              th:action="@{/admin/venues/{id}/unverify(id=${venueView.venue.id})}" 
+                              method="post" class="d-inline-form">
+                            <input type="hidden" name="_method" value="patch">
+                            <input type="hidden" name="status" th:value="${currentStatus}">
+                            <input type="hidden" name="page" th:value="${currentPage}">
+                            <input type="hidden" name="size" th:value="${currentSize}">
+                            <button type="submit" class="btn btn-sm btn-warning" 
+                                    th:text="#{venue.action.unverify}">Bỏ duyệt</button>
+                        </form>
+                    </div>
                 </td>
             </tr>
             <tr th:if="${isShowAll ? #lists.isEmpty(venues) : venues.empty}">
-                <td colspan="7" class="text-center text-muted" th:text="#{venue.table.empty}">No venues found</td>
+                <td colspan="8" class="text-center text-muted" th:text="#{venue.table.empty}">No venues found</td>
             </tr>
         </tbody>
     </table>
@@ -135,7 +143,7 @@
                 <!-- Previous Page -->
                 <li class="page-item" th:classappend="${venues.first} ? 'disabled'">
                     <a class="page-link" 
-                       th:href="@{/admin/venues(name=${currentName}, status=${currentStatus}, sort=${currentSort}, page=${venues.number - 1}, size=${currentSize})}"
+                       th:href="@{/admin/venues/verification(status=${currentStatus}, page=${venues.number - 1}, size=${currentSize})}"
                        th:unless="${venues.first}" th:text="#{pagination.previous}">‹ Previous</a>
                     <span class="page-link text-muted" th:if="${venues.first}" th:text="#{pagination.previous}">‹ Previous</span>
                 </li>
@@ -146,14 +154,14 @@
                     class="page-item"
                     th:classappend="${pageNum == venues.number} ? 'active'">
                     <a class="page-link" 
-                       th:href="@{/admin/venues(name=${currentName}, status=${currentStatus}, sort=${currentSort}, page=${pageNum}, size=${currentSize})}"
+                       th:href="@{/admin/venues/verification(status=${currentStatus}, page=${pageNum}, size=${currentSize})}"
                        th:text="${pageNum + 1}">1</a>
                 </li>
 
                 <!-- Next Page -->  
                 <li class="page-item" th:classappend="${venues.last} ? 'disabled'">
                     <a class="page-link"
-                       th:href="@{/admin/venues(name=${currentName}, status=${currentStatus}, sort=${currentSort}, page=${venues.number + 1}, size=${currentSize})}"
+                       th:href="@{/admin/venues/verification(status=${currentStatus}, page=${venues.number + 1}, size=${currentSize})}"
                        th:unless="${venues.last}" th:text="#{pagination.next}">Next ›</a>
                     <span class="page-link text-muted" th:if="${venues.last}" th:text="#{pagination.next}">Next ›</span>
                 </li>
@@ -168,5 +176,6 @@
         </small>
     </div>
 </div>
+
 </body>
 </html>

--- a/workingspacebooking/src/main/resources/templates/layouts/admin_layout.html
+++ b/workingspacebooking/src/main/resources/templates/layouts/admin_layout.html
@@ -9,36 +9,35 @@
 </head>
 <body>
 
-<div class="container-fluid">
-    <div class="row">
-        <!-- Sidebar -->
-        <div class="col-3 bg-dark vh-100">
-            <div th:replace="~{fragments/sidebar :: sidebarFragment}"></div>
-        </div>
+<div class="admin-layout">
+    <!-- Sidebar -->
+    <div class="sidebar">
+        <div th:replace="~{fragments/sidebar :: sidebarFragment}"></div>
+    </div>
 
-        <!-- Main Content -->
-        <div class="col-9 p-4 bg-white">
-            <!-- Language Switcher -->
-            <div class="d-flex justify-content-end mb-3">
-                <div class="dropdown">
-                    <button class="btn btn-outline-secondary dropdown-toggle btn-sm" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        <i class="bi bi-translate"></i> <span th:text="#{app.language}">Language</span>
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li><a class="dropdown-item language-item" href="#" data-lang="vi" onclick="changeLanguage('vi')">
-                            🇻🇳 <span th:text="#{app.language.vietnamese}">Tiếng Việt</span>
-                        </a></li>
-                        <li><a class="dropdown-item language-item" href="#" data-lang="en" onclick="changeLanguage('en')">
-                            🇺🇸 <span th:text="#{app.language.english}">English</span>
-                        </a></li>
-                    </ul>
+    <!-- Main Content -->
+    <div class="main-content">
+        <!-- Language Switcher -->
+        <div class="d-flex justify-content-end mb-3">
+            <div class="custom-dropdown">
+                <button class="dropdown-btn" type="button" onclick="toggleDropdown()">
+                    <i class="bi bi-translate"></i> <span th:text="#{app.language}">Language</span>
+                    <span class="dropdown-arrow">▼</span>
+                </button>
+                <div class="dropdown-menu-custom" id="languageDropdown">
+                    <a class="dropdown-item language-item" href="#" data-lang="vi">
+                        🇻🇳 <span th:text="#{app.language.vietnamese}">Tiếng Việt</span>
+                    </a>
+                    <a class="dropdown-item language-item" href="#" data-lang="en">
+                        🇺🇸 <span th:text="#{app.language.english}">English</span>
+                    </a>
                 </div>
             </div>
-            
-            <!-- Page Content -->
-            <div layout:fragment="content">
-                <!-- Page content goes here -->
-            </div>
+        </div>
+        
+        <!-- Page Content -->
+        <div layout:fragment="content">
+            <!-- Page content goes here -->
         </div>
     </div>
 </div>


### PR DESCRIPTION
## ✅ Checklist tự review pull trước khi ready để trainer review (Java Spring Boot)
- [x] Sử dụng **thụt lề 4 spaces** đồng nhất ở tất cả các files `.java`, `.xml`, `.html`, `.properties`, v.v. (cấu hình lại IntelliJ/VSCode nếu chưa setup).
- [x] Cuối mỗi file cần có **end line** (`\n`) để tránh lỗi đỏ khi diff trên Git.
- [x] Mỗi dòng nếu quá dài thì cần xuống dòng (tối đa **100 ký tự/dòng**, cài đặt wrap line trong IDE nếu cần).
- [x] `.gitignore` các file nhạy cảm (VD: `application-secret.properties`, `.env`, `/target/`, `.log`, `.class`, ...).
- [x] Tham khảo và tuân theo Java Coding Convention:
  - https://google.github.io/styleguide/javaguide.html
  - hoặc https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
- [x] Kiểm tra mỗi pull request **chỉ có 1 commit**, nếu nhiều hơn hãy dùng `git rebase -i` để gộp commit.
- [x] Cài đặt `Checkstyle`, `PMD`, hoặc plugin Java linter tương ứng trong IDE để kiểm tra coding convention. Format lại trước khi gửi pull.
- [x] Nếu làm việc nhóm, mỗi pull cần **ít nhất 1 APPROVED** từ thành viên khác trong nhóm.

---
## Related Tickets
- [#91151](https://edu-redmine.sun-asterisk.vn/issues/91151)

## WHAT
-   Xây dựng chức năng cho Admin để **duyệt hoặc bỏ duyệt** các địa điểm (Co-working Space) do người dùng (Owner) tạo ra.
-   Tạo một trang quản lý riêng cho việc duyệt địa điểm, tách biệt với trang danh sách chung.
-   Cải tiến giao diện trang quản trị (Admin) với layout, phân trang mới
## HOW
-   **Backend:**
    -   Thêm các endpoint `PATCH /admin/venues/{id}/approve` và `PATCH /admin/venues/{id}/unverify` trong `AdminVenueController` để xử lý logic duyệt/bỏ duyệt.
    -   Bật `HiddenHttpMethodFilter` để cho phép form HTML gửi request `PATCH`.
    -   Trong `VenueService`, triển khai logic thay đổi trạng thái `verified` của `Venue` và thêm các Exception tùy chỉnh (`VenueVerificationException`) để xử lý các trường hợp nghiệp vụ không hợp lệ (ví dụ: duyệt một địa điểm đã được duyệt).
    -   Tạo `AdminExceptionHandler` sử dụng `@ControllerAdvice` để bắt các exception trong luồng admin, hiển thị thông báo lỗi đã được quốc tế hóa (i18n) và chuyển hướng người dùng về trang trước đó.
    -   Cập nhật phương thức `adminListVenues` để hỗ trợ phân trang (`Pageable`) thay vì trả về một danh sách đầy đủ.
-   **Frontend:**
    -   Tạo file verification.html mới làm giao diện chính cho chức năng duyệt, bao gồm form lọc, bảng danh sách các địa điểm và các nút "Duyệt"/"Bỏ duyệt".
    -   Cập nhật list.html để thêm phân trang và một nút điều hướng đến trang duyệt địa điểm.
    -   Sử dụng `RedirectAttributes` để truyền thông báo thành công/lỗi từ Controller sang View sau mỗi hành động.
    -   Cải thiện admin_layout.html và style.css để có bố cục 2 cột (sidebar và content) ổn định hơn.
    -   Thêm các key i18n mới vào file messages_vi.properties và `messages.properties` cho các nhãn, nút bấm và thông báo liên quan.

## Evidence (Screenshot or Video)
### Giao diện quản lý
<img width="2426" height="1376" alt="image" src="https://github.com/user-attachments/assets/73a1293e-db27-4205-9dbd-160789cef929" />

### Phân trang cho danh sách (bổ sung tương tự cho phần xem danh sách)
<img width="1805" height="681" alt="image" src="https://github.com/user-attachments/assets/d954d402-e6c1-43ac-b503-e8469e37f14a" />